### PR TITLE
Merge in FLA modifications to trunk

### DIFF
--- a/software/ovc1/ros/ovc/CMakeLists.txt
+++ b/software/ovc1/ros/ovc/CMakeLists.txt
@@ -4,6 +4,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   roslib
   image_transport
+  camera_info_manager
   cv_bridge
   dynamic_reconfigure
   message_generation
@@ -30,6 +31,7 @@ catkin_package(
     message_runtime
     cv_bridge
     image_transport
+    camera_info_manager
     message_filters
 #  INCLUDE_DIRS include
 #  LIBRARIES falcam
@@ -49,7 +51,7 @@ target_link_libraries(ovc_c ovc)
 
 add_executable(ovc_node ovc_node.cpp)
 add_dependencies(ovc_node
-  ovc_gencfg 
+  ovc_gencfg
   ${ovc_EXPORTED_TARGETS}
   ${catkin_EXPORTED_TARGETS})
 target_link_libraries(ovc_node ovc ${catkin_LIBRARIES})

--- a/software/ovc1/ros/ovc/ovc.cpp
+++ b/software/ovc1/ros/ovc/ovc.cpp
@@ -78,7 +78,7 @@ bool OVC::init()
     return false;
   }
 
-  if (!set_sync_timing(7))
+  if (!set_sync_timing(imu_decimation))
     return false;
 
   if (!set_exposure(0.005)) {
@@ -576,6 +576,10 @@ bool OVC::wait_for_image(uint8_t **p, struct timespec &t)
   printf("wrote image dump file\n");
   */
   return true;
+}
+
+void OVC::set_imu_decimation(const uint8_t imu_decim) {
+  imu_decimation = imu_decim;
 }
 
 bool OVC::set_sync_timing(const uint8_t imu_decimation)

--- a/software/ovc1/ros/ovc/ovc.h
+++ b/software/ovc1/ros/ovc/ovc.h
@@ -19,6 +19,7 @@ public:
   bool set_exposure_and_flash(float exposure_seconds, float flash_seconds);
   bool estimate_timestamp_offset();
   bool set_sync_timing(const uint8_t imu_decimation);
+  void set_imu_decimation(const uint8_t imu_decimation);
   static const int IMAGE_WIDTH = 1280;
   static const int IMAGE_HEIGHT = 2048;
 
@@ -37,6 +38,7 @@ private:
   /////////////////////////////////
   bool init_complete;
   int fd, fd_imu;
+  uint8_t imu_decimation{10};
   uint8_t *dma_buf;
 public:
   double exposure_;

--- a/software/ovc1/ros/ovc/ovc_node.cpp
+++ b/software/ovc1/ros/ovc/ovc_node.cpp
@@ -1,5 +1,6 @@
 #include <cv_bridge/cv_bridge.h>
 #include <image_transport/image_transport.h>
+#include <camera_info_manager/camera_info_manager.h>
 #include <ros/ros.h>
 #include <thread>
 #include <sensor_msgs/Image.h>
@@ -9,19 +10,54 @@
 #include "ovc/ImageCornerArray.h"
 #include "ovc/ImageCorner.h"
 
+using std::string;
+using camera_info_manager::CameraInfoManager;
+using image_transport::ImageTransport;
+
+void setup_publishers(ros::NodeHandle *nh,
+                      ros::NodeHandle *nhs,
+                      string *frame_ids,
+                      std::shared_ptr<ImageTransport> *it,
+                      image_transport::Publisher *cam_pubs,
+                      ros::Publisher *cinfo_pubs,
+                      std::shared_ptr<CameraInfoManager> *cinfo_mgrs) {
+  std::string cname[2] = {"left", "right"};
+  for (int i = 0; i < 2; i++) {
+    // camerainfomanager requires separate node handle so
+    // advertised services don't collide
+    nhs[i] = ros::NodeHandle(*nh, cname[i]);
+    std::string calib_url;
+    nhs[i].param<string>("calib_url", calib_url,
+                      "file://.ros/camera_info_" + cname[i] + ".yaml");
+    nhs[i].param<string>("frame_id", frame_ids[i], "ovc_" + cname[i]);
+
+    it[i].reset(new ImageTransport(nhs[i]));
+    cam_pubs[i] = it[i]->advertise("image_raw", 2);
+    cinfo_pubs[i] = nhs[i].advertise<sensor_msgs::CameraInfo>("camera_info", 2);
+    cinfo_mgrs[i].reset(new CameraInfoManager(nhs[i], cname[i], calib_url));
+  }
+}
+
 void cam_thread_fn(OVC *ovc, ros::NodeHandle *nh)
 {
-  image_transport::ImageTransport image_t(*nh);
+  ImageTransport image_t(*nh);
   image_transport::Publisher image_pub = image_t.advertise("image", 2);
-  image_transport::Publisher single_image_pubs[2] =
-    { image_t.advertise("image_0", 2),
-      image_t.advertise("image_1", 2)};
-  sensor_msgs::ImagePtr img_msg;
-  std_msgs::Header header;
 
   ros::Publisher metadata_pub =
     nh->advertise<ovc::Metadata>("image_metadata", 2);
+
+  ros::NodeHandle                    node_handles[2];
+  std::shared_ptr<ImageTransport>    single_image_t[2];
+  std::shared_ptr<CameraInfoManager> cinfo_mgrs[2];
+  image_transport::Publisher         single_image_pubs[2];
+  ros::Publisher                     camera_info_pubs[2];
+  std::string                        frame_id[2];
+  setup_publishers(nh, node_handles, frame_id, single_image_t,
+                   single_image_pubs, camera_info_pubs, cinfo_mgrs);
+  sensor_msgs::ImagePtr img_msg;
+  std_msgs::Header header;
   ovc::Metadata metadata_msg;
+
   uint8_t *metadata_buf = new uint8_t[256*1024];  // 256k block
 
   while (ros::ok()) {
@@ -48,12 +84,19 @@ void cam_thread_fn(OVC *ovc, ros::NodeHandle *nh)
     const int image_cols = 1280;
     const int single_image_rows = 1024;
     for (int i=0; i<2; i++) {
+      header.frame_id = frame_id[i];
       if (single_image_pubs[i].getNumSubscribers() > 0) {
         cv::Mat subimg(img, cv::Rect(0, single_image_rows * i,
                                      image_cols, single_image_rows));
         const sensor_msgs::ImagePtr single_img_msg =
           cv_bridge::CvImage(header, "mono8", subimg).toImageMsg();
         single_image_pubs[i].publish(single_img_msg);
+      }
+      if (camera_info_pubs[i].getNumSubscribers() > 0) {
+        const auto cinfo_msg = boost::make_shared<sensor_msgs::CameraInfo>(
+                                cinfo_mgrs[i]->getCameraInfo());
+        cinfo_msg->header = header;
+        camera_info_pubs[i].publish(cinfo_msg);
       }
     }
 

--- a/software/ovc1/ros/ovc/package.xml
+++ b/software/ovc1/ros/ovc/package.xml
@@ -9,6 +9,7 @@
   <build_depend>roslib</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>camera_info_manager</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>message_filters</build_depend>
   <run_depend>roscpp</run_depend>
@@ -18,6 +19,7 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>image_transport</run_depend>
+  <run_depend>camera_info_manager</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>message_filters</run_depend>
   <buildtool_depend>catkin</buildtool_depend>

--- a/software/ovc1/scripts/init_fpga.sh
+++ b/software/ovc1/scripts/init_fpga.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
-set -o verbose
-cd ~/ovc/software/ovc1/ovc_module
-sudo ./ovc_load
-sleep 3
-cp /home/nvidia/ovc/firmware/ovc1/fpga/stable/ovc.core.rbf /dev/ovc_cvp
-sleep 3
-sudo rmmod ovc
-sudo ./ovc_load
+file=/tmp/ovc_fpga_init
+
+if [ ! -f $file ]; then
+  echo "OVC_FPGA_INIT=true" >> /tmp/ovc_fpga_init
+  echo "Initializing FPGA..."
+  echo "save state at: $file"
+  set -o verbose
+  cd ~/ovc/software/ovc1/ovc_module
+  sudo ./ovc_load
+  sleep 3
+  cp ~/ovc/firmware/ovc1/fpga/stable/ovc.core.rbf /dev/ovc_cvp
+  sleep 3
+  sudo rmmod ovc
+  sudo ./ovc_load
+fi


### PR DESCRIPTION
Bernd made a couple changes to the driver that the rest of our software stack needs.  These had been merged into opencam, but didn't make the transition when opencam turned into the ovc repo.  Two major changes:

1. Making imu_decim a parameter and changing the default fps to 20
2. Adding separate image publishers for the 2 images, as well as adding camera_info topics for each