### PR TITLE
Fix msg build bug and cleanup package.xml

### DIFF
--- a/software/ovc3/ovc_embedded_driver/CMakeLists.txt
+++ b/software/ovc3/ovc_embedded_driver/CMakeLists.txt
@@ -13,7 +13,7 @@ add_message_files(
    Metadata.msg
 )
 
- add_service_files(
+add_service_files(
    FILES
    ConfigureFAST.srv
 )
@@ -25,8 +25,8 @@ generate_messages(
 
 catkin_package(
   INCLUDE_DIRS include
+  CATKIN_DEPENDS message_runtime
 #  LIBRARIES ovc_embedded_driver
-#  CATKIN_DEPENDS other_catkin_pkg
 #  DEPENDS system_lib
 )
 
@@ -43,8 +43,10 @@ add_library(${PROJECT_NAME}
   src/dma_shapeshifter.cpp
   src/image_publisher.cpp
 )
+add_dependencies(${PROJECT_NAME} ovc_embedded_driver_generate_messages_cpp)
 
 add_executable(${PROJECT_NAME}_node src/ovc_embedded_driver_node.cpp)
+add_dependencies(${PROJECT_NAME}_node ovc_embedded_driver_generate_messages_cpp)
 add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME}_node
   ${catkin_LIBRARIES}

--- a/software/ovc3/ovc_embedded_driver/package.xml
+++ b/software/ovc3/ovc_embedded_driver/package.xml
@@ -3,60 +3,17 @@
   <name>ovc_embedded_driver</name>
   <version>0.0.0</version>
   <description>The ovc_embedded_driver package</description>
-
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="luca@openrobotics.org">Luca Della Vedova</maintainer>
+  <license>Apache</license>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
-
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/ovc_embedded_driver</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
-  <depend>roscpp</depend>
-  <depend>topic_tools</depend>
-  <depend>std_msgs</depend>
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>topic_tools</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>message_runtime</build_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
 </package>


### PR DESCRIPTION
There is a very common bug with ROS custom messages where an explicit dependency is not declared for any targets in CMakeLists.txt for the messages to be built BEFORE linking them. This fixes that, and also cleans up and adds a license to package.xml.