### PR TITLE
Refactor Image and IMU Publishers

### DIFF
--- a/software/ovc3/ovc_embedded_driver/include/ovc_embedded_driver/image_publisher.h
+++ b/software/ovc3/ovc_embedded_driver/include/ovc_embedded_driver/image_publisher.h
@@ -39,8 +39,6 @@ class ImagePublisher
   sensor_msgs::Image image_msg;
 
   std::shared_ptr<AtomicRosTime> time_ptr;
-  std::condition_variable& time_condition_var;
-  std::unique_lock<std::mutex>& time_guard;
 
   size_t image_msg_size;
   bool run_fast;
@@ -51,9 +49,7 @@ class ImagePublisher
 public:
   ImagePublisher(ros::NodeHandle nh_p,
                  CameraHWParameters params,
-                 std::shared_ptr<AtomicRosTime> t_ptr,
-                 std::condition_variable& t_cond_var,
-                 std::unique_lock<std::mutex>& t_guard);
+                 std::shared_ptr<AtomicRosTime> t_ptr);
 
   void publish();
 };

--- a/software/ovc3/ovc_embedded_driver/include/ovc_embedded_driver/image_publisher.h
+++ b/software/ovc3/ovc_embedded_driver/include/ovc_embedded_driver/image_publisher.h
@@ -17,10 +17,10 @@ namespace ovc_embedded_driver {
 
 template <typename T>
 void SerializeToByteArray(const T& msg, std::vector<uint8_t>& destination_buffer)
-{ 
+{
   const uint32_t length = ros::serialization::serializationLength(msg);
   destination_buffer.resize( length );
-  //copy into your own buffer 
+  //copy into your own buffer
   ros::serialization::OStream stream(destination_buffer.data(), length);
   ros::serialization::serialize(stream, msg);
 }
@@ -41,13 +41,13 @@ class ImagePublisher
   std::shared_ptr<AtomicRosTime> time_ptr;
 
   size_t image_msg_size;
-  
   bool run_fast;
-
   void publishCorners(const ros::Time& frame_time);
 
 public:
-  ImagePublisher(ros::NodeHandle nh_p, CameraHWParameters params, std::shared_ptr<AtomicRosTime> t_ptr);
+  ImagePublisher(ros::NodeHandle nh_p,
+                 CameraHWParameters params,
+                 std::shared_ptr<AtomicRosTime> t_ptr);
 
   void publish();
 };

--- a/software/ovc3/ovc_embedded_driver/include/ovc_embedded_driver/image_publisher.h
+++ b/software/ovc3/ovc_embedded_driver/include/ovc_embedded_driver/image_publisher.h
@@ -39,15 +39,21 @@ class ImagePublisher
   sensor_msgs::Image image_msg;
 
   std::shared_ptr<AtomicRosTime> time_ptr;
+  std::condition_variable& time_condition_var;
+  std::unique_lock<std::mutex>& time_guard;
 
   size_t image_msg_size;
   bool run_fast;
   void publishCorners(const ros::Time& frame_time);
 
+  uint8_t last_time_write_count;
+
 public:
   ImagePublisher(ros::NodeHandle nh_p,
                  CameraHWParameters params,
-                 std::shared_ptr<AtomicRosTime> t_ptr);
+                 std::shared_ptr<AtomicRosTime> t_ptr,
+                 std::condition_variable& t_cond_var,
+                 std::unique_lock<std::mutex>& t_guard);
 
   void publish();
 };

--- a/software/ovc3/ovc_embedded_driver/include/ovc_embedded_driver/spi_driver.h
+++ b/software/ovc3/ovc_embedded_driver/include/ovc_embedded_driver/spi_driver.h
@@ -8,8 +8,6 @@ struct IMUReading
 {
   float a_x, a_y, a_z;
   float g_x, g_y, g_z; 
-
-  int num_sample; // Number relative to start of frame, 0 means synchronised with frame start
 };
 
 class SPIDriver 
@@ -65,6 +63,7 @@ class SPIDriver
 
 public:
   SPIDriver(int gpio_uio_num);
+  int getSampleNumber();
   IMUReading readSensors();
 
 };

--- a/software/ovc3/ovc_embedded_driver/include/ovc_embedded_driver/utilities.h
+++ b/software/ovc3/ovc_embedded_driver/include/ovc_embedded_driver/utilities.h
@@ -2,7 +2,9 @@
 #define OVC_UTILITIES_H
 
 #include <mutex>
+#include <atomic>
 
+#include <ovc_embedded_driver/sensor_constants.h>
 #include <ros/ros.h>
 
 namespace ovc_embedded_driver {
@@ -10,25 +12,21 @@ namespace ovc_embedded_driver {
 // Class used for multithreaded access / update of ros time variable
 class AtomicRosTime
 {
-  std::mutex time_mutex;
-
-  ros::Time time; 
+private:
+  std::mutex time_ops_mutex;
+  ros::Time time;
 
 public:
-
-  void update() { 
-    std::lock_guard<std::mutex> lock(time_mutex);
-    time = ros::Time::now();
+  void update(const ros::Time& t) {
+    std::lock_guard<std::mutex> lock(time_ops_mutex);
+    time = t;
   }
 
   ros::Time get() {
-    std::lock_guard<std::mutex> lock(time_mutex);
+    std::lock_guard<std::mutex> lock(time_ops_mutex);
     return time;
   }
 };
-
-
-
 
 } // namespace ovc_embedded_driver
 

--- a/software/ovc3/ovc_embedded_driver/include/ovc_embedded_driver/utilities.h
+++ b/software/ovc3/ovc_embedded_driver/include/ovc_embedded_driver/utilities.h
@@ -17,6 +17,12 @@ private:
   ros::Time time;
 
 public:
+  // These variables are public to save on function call overhead
+  std::atomic<uint8_t> time_read_count;
+  std::atomic<uint8_t> time_write_count;
+
+  AtomicRosTime() : time_read_count(0), time_write_count(0) {}
+
   void update(const ros::Time& t) {
     std::lock_guard<std::mutex> lock(time_ops_mutex);
     time = t;
@@ -26,6 +32,15 @@ public:
     std::lock_guard<std::mutex> lock(time_ops_mutex);
     return time;
   }
+
+  // Getters and setters
+  void increment_read_count() { time_read_count += 1; }
+  void increment_write_count() { time_write_count += 1; }
+  void reset_read_count() { time_read_count = 0; }
+  void reset_write_count() { time_write_count = 0; }
+
+  uint8_t get_read_count() { return time_read_count.load(); }
+  uint8_t get_write_count() { return time_write_count.load(); }
 };
 
 } // namespace ovc_embedded_driver

--- a/software/ovc3/ovc_embedded_driver/src/image_publisher.cpp
+++ b/software/ovc3/ovc_embedded_driver/src/image_publisher.cpp
@@ -8,9 +8,16 @@
 
 using namespace ovc_embedded_driver;
 
-ImagePublisher::ImagePublisher(ros::NodeHandle nh_p, CameraHWParameters params, std::shared_ptr<AtomicRosTime> t_ptr) : nh(nh_p), i2c(params.i2c_num), time_ptr(t_ptr), run_fast(!params.is_rgb)
+ImagePublisher::ImagePublisher(ros::NodeHandle nh_p,
+                               CameraHWParameters params,
+                               std::shared_ptr<AtomicRosTime> t_ptr)
+  : nh(nh_p)
+  , i2c(params.i2c_num)
+  , time_ptr(t_ptr)
+  , run_fast(!params.is_rgb)
 {
   const std::string img_namespace("ovc/" + params.camera_name + "/");
+
   // Prepare the shapeshifter
   shape_shifter.morph(
                   ros::message_traits::MD5Sum<sensor_msgs::Image>::value(),

--- a/software/ovc3/ovc_embedded_driver/src/ovc_embedded_driver_node.cpp
+++ b/software/ovc3/ovc_embedded_driver/src/ovc_embedded_driver_node.cpp
@@ -46,7 +46,7 @@ void update_time_ptr(ros::NodeHandle nh,
     new_imu_sample = true;
     num_sample_condition_var.notify_all();
 
-    curr_time_ptr->update(ros::Time::now());
+    curr_time_ptr->update_no_notify(ros::Time::now());
 
     // Only update time on the 7th IMU sample
     if (num_sample == 0)
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
   }
 
   // INIT
-  curr_time_ptr->update(ros::Time::now());
+  curr_time_ptr->update_no_notify(ros::Time::now());
   frame_time_ptr->update(curr_time_ptr->get());
 
   spinner.start();

--- a/software/ovc3/ovc_embedded_driver/src/ovc_embedded_driver_node.cpp
+++ b/software/ovc3/ovc_embedded_driver/src/ovc_embedded_driver_node.cpp
@@ -1,6 +1,7 @@
 #include <thread>
 #include <memory>
 #include <string>
+#include <condition_variable>
 
 #include <ros/ros.h>
 #include <sensor_msgs/Imu.h>
@@ -24,17 +25,58 @@ const int FAST_CONFIG_GPIO = 5; // UIO device for corner detection configuration
 
 const int COLOR_CAMERA_ID = 2; // The only color camera is CAM2
 
-void publish_imu(ros::NodeHandle nh, std::shared_ptr<AtomicRosTime> time_ptr)
+SPIDriver spi(IMU_SYNC_GPIO);
+
+// Condition Variables
+std::condition_variable num_sample_condition_var;
+std::mutex num_sample_guard_mutex;
+std::unique_lock<std::mutex> num_sample_guard(num_sample_guard_mutex);
+
+// IMU publisher synchronisation vars
+int num_sample = -1;
+std::atomic<bool> new_imu_sample(false);
+
+void update_time_ptr(ros::NodeHandle nh,
+                     std::shared_ptr<AtomicRosTime> time_ptr,
+                     std::shared_ptr<AtomicRosTime> curr_time_ptr)
 {
-  SPIDriver spi(IMU_SYNC_GPIO);
-  ros::Publisher imu_pub = nh.advertise<sensor_msgs::Imu>("/ovc/imu", 10);
-  sensor_msgs::Imu imu_msg;
   while (ros::ok())
   {
+    num_sample = spi.getSampleNumber(); // Blocking call
+    new_imu_sample = true;
+    num_sample_condition_var.notify_all();
+
+    curr_time_ptr->update(ros::Time::now());
+
+    // Only update time on the 7th IMU sample
+    if (num_sample == 0)
+    {
+      time_ptr->update(curr_time_ptr->get());
+    }
+  }
+}
+
+void publish_imu(ros::NodeHandle nh,
+                 std::shared_ptr<AtomicRosTime> time_ptr,
+                 std::shared_ptr<AtomicRosTime> curr_time_ptr)
+{
+  ros::Publisher imu_pub = nh.advertise<sensor_msgs::Imu>("/ovc/imu", 10);
+  sensor_msgs::Imu imu_msg;
+
+  while (ros::ok())
+  {
+    // If a new IMU sample has not been detected yet, wait
+    while (!new_imu_sample.load())
+    {
+      num_sample_condition_var.wait(num_sample_guard);
+    }
+    new_imu_sample = false;
+
     IMUReading imu = spi.readSensors();
+
     // TODO check if delay incurred by SPI transaction is indeed negligible
 
-    imu_msg.header.stamp = ros::Time::now();
+    imu_msg.header.stamp = curr_time_ptr->get();
     imu_msg.header.frame_id = "ovc_imu_link";
 
     imu_msg.angular_velocity.x = imu.g_x;
@@ -46,14 +88,12 @@ void publish_imu(ros::NodeHandle nh, std::shared_ptr<AtomicRosTime> time_ptr)
 
     // Sample synchronised with frame trigger
     imu_pub.publish(imu_msg);
-    if (imu.num_sample == 0)
-      time_ptr->update();
   }
 }
 
 void configureFAST(bool enable, int thresh)
 {
-  static UIODriver uio(FAST_CONFIG_GPIO, 0x1000); 
+  static UIODriver uio(FAST_CONFIG_GPIO, 0x1000);
   uint32_t write_val = thresh & 0xFF;
   write_val |= enable << 8;
   uio.writeRegister(0, write_val);
@@ -67,22 +107,40 @@ bool configureFAST_cb(ConfigureFAST::Request &req, ConfigureFAST::Response &res)
 
 int main(int argc, char **argv)
 {
+  // Init ROS
   ros::init(argc, argv, "ovc_embedded_driver_node");
   ros::NodeHandle nh;
+
+  std::shared_ptr<AtomicRosTime> curr_time_ptr = std::make_shared<AtomicRosTime>();
   std::shared_ptr<AtomicRosTime> time_ptr = std::make_shared<AtomicRosTime>();
-  configureFAST(1, 25);
   ros::ServiceServer fast_serv = nh.advertiseService("/ovc/configure_fast", configureFAST_cb);
   ros::AsyncSpinner spinner(1);
-  std::unique_ptr<std::thread> threads[NUM_CAMERAS + 1]; // one for IMU
-  threads[NUM_CAMERAS] = std::make_unique<std::thread>(publish_imu, nh, time_ptr);
+
+  configureFAST(1, 60);
+
+  // Init threads
+  std::unique_ptr<std::thread> threads[NUM_CAMERAS + 2]; // one each for IMU and time_ptr update threads
   std::unique_ptr<ImagePublisher> image_publisher[NUM_CAMERAS];
+
+  // IMU thread
+  threads[NUM_CAMERAS] = std::make_unique<std::thread>(publish_imu, nh, time_ptr, curr_time_ptr);
+
+  // Time object update thread
+  threads[NUM_CAMERAS + 1] = std::make_unique<std::thread>(update_time_ptr, nh, time_ptr, curr_time_ptr);
+
+  // Image Publisher threads
   for (size_t i=0; i<NUM_CAMERAS; ++i)
   {
     CameraHWParameters params(DMA_DEVICES[i], I2C_DEVICES[i], CAMERA_NAMES[i], i == COLOR_CAMERA_ID);
     image_publisher[i] = std::make_unique<ImagePublisher>(nh, params, time_ptr);
     threads[i] = std::make_unique<std::thread>(&ImagePublisher::publish, image_publisher[i].get());
   }
+
+  // INIT
+  time_ptr->update(ros::Time::now());
+  curr_time_ptr->update(ros::Time::now());
   spinner.start();
 
+  // Wait for each thread to end
   threads[NUM_CAMERAS]->join();
 }

--- a/software/ovc3/ovc_embedded_driver/src/ovc_embedded_driver_node.cpp
+++ b/software/ovc3/ovc_embedded_driver/src/ovc_embedded_driver_node.cpp
@@ -32,10 +32,6 @@ std::condition_variable num_sample_condition_var;
 std::mutex num_sample_guard_mutex;
 std::unique_lock<std::mutex> num_sample_guard(num_sample_guard_mutex);
 
-std::condition_variable time_condition_var;
-std::mutex time_guard_mutex;
-std::unique_lock<std::mutex> time_guard(time_guard_mutex);
-
 // IMU publisher synchronisation vars
 int num_sample = -1;
 std::atomic<bool> new_imu_sample(false);

--- a/software/ovc3/ovc_embedded_driver/src/spi_driver.cpp
+++ b/software/ovc3/ovc_embedded_driver/src/spi_driver.cpp
@@ -7,10 +7,13 @@
 
 #include <ovc_embedded_driver/spi_driver.h>
 
+static constexpr float DEG_TO_RAD(0.0174533);
+static constexpr float G_TO_METRES(9.80665);
+
 SPIDriver::SPIDriver(int gpio_uio_num) :
   accel_sens(DEFAULT_ACCEL_SENS), gyro_sens(DEFAULT_GYRO_SENS), uio(UIODriver(gpio_uio_num, GPIO_UIO_SIZE))
 {
-  spi_fd = open("/dev/spidev2.0", O_RDWR);
+  spi_fd = open("/dev/spidev1.0", O_RDWR);
 
   if (spi_fd < 0)
     std::cout << "Failed in opening spi file" << std::endl;
@@ -85,30 +88,39 @@ void SPIDriver::burstReadRegister(unsigned char addr, int count)
   Transmit(1,count);
 }
 
-IMUReading SPIDriver::readSensors()
+int SPIDriver::getSampleNumber()
 {
   // Wait for new data available
   uio.waitInterrupt();
+  return uio.readRegister(GPIO_DATA);
+}
+
+IMUReading SPIDriver::readSensors()
+{
   // TODO add temperature / compass?
   IMUReading ret;
   // TODO make high level function for specific uio, maybe inheriting
-  ret.num_sample = uio.readRegister(GPIO_DATA);
   tx_buf[0] = ACCEL_XOUT_H | MASK_READ;
   Transmit(1, 12);
   // Cast to make sure we don't lose the sign
-  ret.a_x = static_cast<int16_t>(rx_buf[0] << 8 | rx_buf[1]) * accel_sens;
-  ret.a_y = static_cast<int16_t>(rx_buf[2] << 8 | rx_buf[3]) * accel_sens;
-  ret.a_z = static_cast<int16_t>(rx_buf[4] << 8 | rx_buf[5]) * accel_sens;
-  ret.g_x = static_cast<int16_t>(rx_buf[6] << 8 | rx_buf[7]) * gyro_sens;
-  ret.g_y = static_cast<int16_t>(rx_buf[8] << 8 | rx_buf[9]) * gyro_sens;
-  ret.g_z = static_cast<int16_t>(rx_buf[10] << 8 | rx_buf[11]) * gyro_sens;
+
+  // Linear Accelerations
+  ret.a_x = static_cast<int16_t>(rx_buf[0] << 8 | rx_buf[1]) * accel_sens * G_TO_METRES;
+  ret.a_y = static_cast<int16_t>(rx_buf[2] << 8 | rx_buf[3]) * accel_sens * G_TO_METRES;
+  ret.a_z = static_cast<int16_t>(rx_buf[4] << 8 | rx_buf[5]) * accel_sens * G_TO_METRES;
+
+  // Angular velocities
+  ret.g_x = static_cast<int16_t>(rx_buf[6] << 8 | rx_buf[7]) * gyro_sens * DEG_TO_RAD;
+  ret.g_y = static_cast<int16_t>(rx_buf[8] << 8 | rx_buf[9]) * gyro_sens * DEG_TO_RAD;
+  ret.g_z = static_cast<int16_t>(rx_buf[10] << 8 | rx_buf[11]) * gyro_sens * DEG_TO_RAD;
+
   //std::cout << "Got IMU n. " << ret.num_sample << std::endl;
   return ret;
 }
 
 void SPIDriver::Transmit(size_t tx_len, size_t rx_len)
 {
-  struct spi_ioc_transfer xfer[2]; 
+  struct spi_ioc_transfer xfer[2];
   memset(xfer, 0, sizeof xfer);
   xfer[0].tx_buf = (uint64_t) tx_buf;
   xfer[0].len = tx_len;


### PR DESCRIPTION
The previous method of publishing IMU messages led to a possible lag in the updating of the shared time accessed by the Image Publishers. This leads to some images getting sent with duplicate timestamps, which can break some algorithms.

This issue was solved by splitting the IMU reading and time updating tasks into separate threads, and by using a condition variable to signal when a new sample has been read.

This in effect allows the image timestamps to update quickly, without risk of delay due to IMU readings, which would originally lead to duplicate image timestamps occuring if the delay is too great.

This PR also implements a condition variable to ensure new images are only published on an updated timestamp.