### PR TITLE
Config File

### DIFF
--- a/ovc5/software/camera_device_driver/CMakeLists.txt
+++ b/ovc5/software/camera_device_driver/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(ovc5_cameras
 
 target_link_libraries(ovc5_cameras
   ovc5_library
+  yaml-cpp
 )
 
 add_executable(ovc5_driver src/ovc5_driver.cpp)

--- a/ovc5/software/config.yaml
+++ b/ovc5/software/config.yaml
@@ -1,0 +1,7 @@
+# Configuration should match devices in /sys/class/uio/ for dma/timers and
+#   /sys/class/i2c-dev/ for i2c.
+# NOTE: `cat` their `name` file to find the device type.
+i2c_devs: [2, 3]
+vdma_devs: [1, 0]
+trigger_timer_dev: 3
+line_count_timer_dev: 2


### PR DESCRIPTION
This adds a config file which allows the user to re-configure the OVC without needing to re-compile. The new values match the i2c/dma/timer values found in the auto-generated boot disk. I am debating if the file should be passed as an a path instead of just requiring a file `config.yaml` to exist in the directory the executable is called from. @luca-della-vedova what do you think?