### PR TITLE
Imager Datatype Passthrough

### DIFF
--- a/ovc5/software/camera_device_driver/include/ovc5_driver/camera.hpp
+++ b/ovc5/software/camera_device_driver/include/ovc5_driver/camera.hpp
@@ -6,19 +6,13 @@
 #include "ovc5_driver/i2c_driver.h"
 #include "ovc5_driver/vdma_driver.h"
 
-enum class sensor_type_t
-{
-  PiCameraV2,
-  PiCameraHQ,
-  AR0521
-};
-
 typedef struct camera_params_t
 {
   int res_x = -1;
   int res_y = -1;
   int fps = -1;
   int bit_depth = -1;
+  char data_type[8] = "";
 } camera_params_t;
 
 // TODO move to separate shared header if we want to serialize manually
@@ -42,8 +36,6 @@ public:
       : i2c(std::move(i2c_dev)), vdma(vdma_dev, cam_id), main_camera(main_cam)
   {
   }
-
-  // virtual sensor_type_t getType() const = 0;
 
   // TODO add an initialise function with custom sensor mode
   virtual bool initialise(std::string config_name = "__default__") = 0;

--- a/ovc5/software/camera_device_driver/include/ovc5_driver/camera.hpp
+++ b/ovc5/software/camera_device_driver/include/ovc5_driver/camera.hpp
@@ -12,7 +12,7 @@ typedef struct camera_params_t
   int res_y = -1;
   int fps = -1;
   int bit_depth = -1;
-  char data_type[8] = "";
+  char data_type[8];
 } camera_params_t;
 
 // TODO move to separate shared header if we want to serialize manually

--- a/ovc5/software/camera_device_driver/include/ovc5_driver/cameras/picam_v2.hpp
+++ b/ovc5/software/camera_device_driver/include/ovc5_driver/cameras/picam_v2.hpp
@@ -95,7 +95,7 @@ private:
            .res_y = 2564,
            .fps = 21,
            .bit_depth = 10,
-           .data_type = {'B', 'y', 'r', 'R', 'G', 'G', 'B', '\n'},
+           .data_type = {'B', 'y', 'r', 'R', 'G', 'G', 'B', '\0'},
        }},
       {"1920x1080_30fps",
        {
@@ -103,7 +103,7 @@ private:
            .res_y = 1080,
            .fps = 30,
            .bit_depth = 10,
-           .data_type = {'B', 'y', 'r', 'R', 'G', 'G', 'B', '\n'},
+           .data_type = {'B', 'y', 'r', 'R', 'G', 'G', 'B', '\0'},
        }},
       {"1280x720_120fps",
        {
@@ -111,7 +111,7 @@ private:
            .res_y = 720,
            .fps = 120,
            .bit_depth = 10,
-           .data_type = {'B', 'y', 'r', 'R', 'G', 'G', 'B', '\n'},
+           .data_type = {'B', 'y', 'r', 'R', 'G', 'G', 'B', '\0'},
        }},
   };
 

--- a/ovc5/software/camera_device_driver/include/ovc5_driver/cameras/picam_v2.hpp
+++ b/ovc5/software/camera_device_driver/include/ovc5_driver/cameras/picam_v2.hpp
@@ -95,6 +95,7 @@ private:
            .res_y = 2564,
            .fps = 21,
            .bit_depth = 10,
+           .data_type = {'B', 'y', 'r', 'R', 'G', 'G', 'B', '\n'},
        }},
       {"1920x1080_30fps",
        {
@@ -102,6 +103,7 @@ private:
            .res_y = 1080,
            .fps = 30,
            .bit_depth = 10,
+           .data_type = {'B', 'y', 'r', 'R', 'G', 'G', 'B', '\n'},
        }},
       {"1280x720_120fps",
        {
@@ -109,6 +111,7 @@ private:
            .res_y = 720,
            .fps = 120,
            .bit_depth = 10,
+           .data_type = {'B', 'y', 'r', 'R', 'G', 'G', 'B', '\n'},
        }},
   };
 

--- a/ovc5/software/camera_device_driver/include/ovc5_driver/cameras/picam_v2.hpp
+++ b/ovc5/software/camera_device_driver/include/ovc5_driver/cameras/picam_v2.hpp
@@ -95,6 +95,9 @@ private:
            .res_y = 2564,
            .fps = 21,
            .bit_depth = 10,
+           // The data type cannot be defined as a string due to a compiler bug
+           // resolved in GCC 11. See:
+           // https://github.com/osrf/ovc/pull/59#discussion_r687052682
            .data_type = {'B', 'y', 'r', 'R', 'G', 'G', 'B', '\0'},
        }},
       {"1920x1080_30fps",

--- a/ovc5/software/camera_device_driver/src/ethernet_driver.cpp
+++ b/ovc5/software/camera_device_driver/src/ethernet_driver.cpp
@@ -36,6 +36,7 @@ void EthernetClient::send(unsigned char *imgdata, const camera_params_t &params)
   */
   tx_pkt.frame.height = params.res_y;
   tx_pkt.frame.width = params.res_x;
+  strncpy(tx_pkt.frame.data_type, params.data_type, sizeof(*params.data_type));
   tx_pkt.frame.step = std::round(params.res_x * (params.bit_depth / 8.0));
   int frame_size = tx_pkt.frame.height * tx_pkt.frame.step;
   int cur_off = 0;

--- a/ovc5/software/camera_device_driver/src/ethernet_driver.cpp
+++ b/ovc5/software/camera_device_driver/src/ethernet_driver.cpp
@@ -36,7 +36,7 @@ void EthernetClient::send(unsigned char *imgdata, const camera_params_t &params)
   */
   tx_pkt.frame.height = params.res_y;
   tx_pkt.frame.width = params.res_x;
-  strncpy(tx_pkt.frame.data_type, params.data_type, sizeof(*params.data_type));
+  strncpy(tx_pkt.frame.data_type, params.data_type, sizeof(params.data_type));
   tx_pkt.frame.step = std::round(params.res_x * (params.bit_depth / 8.0));
   int frame_size = tx_pkt.frame.height * tx_pkt.frame.step;
   int cur_off = 0;

--- a/ovc5/software/camera_host_driver/src/ovc5_host_driver.cpp
+++ b/ovc5/software/camera_host_driver/src/ovc5_host_driver.cpp
@@ -37,9 +37,19 @@ int main(int argc, char** argv)
   {
     auto frames = ovc.getFrames();
 
-    cv::Mat frame;
-    cv::hconcat(frames[0].image, frames[1].image, frame);
-    float scale = (float)SCREEN_WIDTH / frame.size().width;
+    float scale = 1.0;
+    cv::Mat frame, img0 = frames[0].image, img1 = frames[1].image;
+    if (img0.rows != img1.rows) {
+      if (img0.rows > img1.rows) {
+        scale = (float) img0.rows / img1.rows;
+        cv::resize(img1, img1, cv::Size(), scale, scale);
+      } else {
+        scale = (float) img1.rows / img0.rows;
+        cv::resize(img0, img0, cv::Size(), scale, scale);
+      }
+    }
+    cv::hconcat(img0, img1, frame);
+    scale = (float)SCREEN_WIDTH / frame.size().width;
     cv::resize(frame, frame, cv::Size(), scale, scale);
     cv::imshow("ovc", frame);
     cv::waitKey(1);

--- a/ovc5/software/camera_host_driver/src/ovc5_host_driver.cpp
+++ b/ovc5/software/camera_host_driver/src/ovc5_host_driver.cpp
@@ -39,12 +39,16 @@ int main(int argc, char** argv)
 
     float scale = 1.0;
     cv::Mat frame, img0 = frames[0].image, img1 = frames[1].image;
-    if (img0.rows != img1.rows) {
-      if (img0.rows > img1.rows) {
-        scale = (float) img0.rows / img1.rows;
+    if (img0.rows != img1.rows)
+    {
+      if (img0.rows > img1.rows)
+      {
+        scale = (float)img0.rows / img1.rows;
         cv::resize(img1, img1, cv::Size(), scale, scale);
-      } else {
-        scale = (float) img1.rows / img0.rows;
+      }
+      else
+      {
+        scale = (float)img1.rows / img0.rows;
         cv::resize(img0, img0, cv::Size(), scale, scale);
       }
     }

--- a/ovc5/software/libovc/include/libovc/server.hpp
+++ b/ovc5/software/libovc/include/libovc/server.hpp
@@ -19,12 +19,18 @@ enum class ReceiveState
   WAIT_PAYLOAD,
 };
 
+std::unordered_map<std::string, cv::ColorConversionCodes> = {
+    {"BYR_RGGB", cv::COLOR_BayerBG2BGR},
+    {"BYR_GRGB", cv::COLOR_BayerGR2RGB},
+};
+
 // TODO sensor name / mode?
 typedef struct OVCImage
 {
   uint64_t t_sec;
   uint64_t t_nsec;
   uint64_t frame_id;
+  cv::ColorConversionCodes color_format;
   cv::Mat image;
 } OVCImage;
 

--- a/ovc5/software/libovc/include/libovc/server.hpp
+++ b/ovc5/software/libovc/include/libovc/server.hpp
@@ -37,10 +37,20 @@ public:
 private:
   static constexpr int BASE_PORT = 12345;
 
+  // The Bayer Pattern is as follows:
+  //
+  //     * * * * * * * * * *
+  //     * R G R G R G R G *
+  //     * G B G B G B G B *
+  //     * * * * * * * * * *
+  //
+  // Depending on the direction x and y increment when reading out the data,
+  // the order will change. This order determines the selection within the
+  // color map.
   const std::unordered_map<std::string, cv::ColorConversionCodes>
       color_code_map = {
-          {"ByrRGGB", cv::COLOR_BayerBG2BGR},
-          {"ByrGRGB", cv::COLOR_BayerGR2RGB},
+          {"ByrRGGB", cv::COLOR_BayerBG2BGR},  // Left to Right, Top to Bottom.
+          {"ByrGRBG", cv::COLOR_BayerGR2RGB},  // Right to Left, Top to Bottom.
   };
 
   ReceiveState state_ = ReceiveState::WAIT_HEADER;

--- a/ovc5/software/libovc/include/libovc/server.hpp
+++ b/ovc5/software/libovc/include/libovc/server.hpp
@@ -19,11 +19,6 @@ enum class ReceiveState
   WAIT_PAYLOAD,
 };
 
-std::unordered_map<std::string, cv::ColorConversionCodes> = {
-    {"BYR_RGGB", cv::COLOR_BayerBG2BGR},
-    {"BYR_GRGB", cv::COLOR_BayerGR2RGB},
-};
-
 // TODO sensor name / mode?
 typedef struct OVCImage
 {
@@ -41,6 +36,12 @@ public:
 
 private:
   static constexpr int BASE_PORT = 12345;
+
+  const std::unordered_map<std::string, cv::ColorConversionCodes>
+      color_code_map = {
+          {"ByrRGGB", cv::COLOR_BayerBG2BGR},
+          {"ByrGRGB", cv::COLOR_BayerGR2RGB},
+  };
 
   ReceiveState state_ = ReceiveState::WAIT_HEADER;
 

--- a/ovc5/software/libovc/src/ovc.cpp
+++ b/ovc5/software/libovc/src/ovc.cpp
@@ -48,7 +48,7 @@ std::array<OVCImage, Server::NUM_IMAGERS> OVC::getFrames()
   for (size_t i = 0; i < frames_.size(); i++)
   {
     cv::Mat shifted = unpackTo16(frames_[i].image);
-    cv::cvtColor(shifted, frames_[i].image, cv::COLOR_BayerBG2BGR);
+    cv::cvtColor(shifted, frames_[i].image, frames_[i].color_format);
   }
 
   return frames_;

--- a/ovc5/software/libovc/src/server.cpp
+++ b/ovc5/software/libovc/src/server.cpp
@@ -81,8 +81,7 @@ void Server::receiveThread()
       ret_imgs[camera_id].t_sec = recv_pkt.frame.t_sec;
       ret_imgs[camera_id].t_nsec = recv_pkt.frame.t_nsec;
       ret_imgs[camera_id].frame_id = recv_pkt.frame.frame_id;
-      ret_imgs[camera_id].color_format =
-          color_code_map.at(recv_pkt.frame.data_type);
+      ret_imgs[camera_id].color_format = color_code_map.at(recv_pkt.frame.data_type);
 
       frame_size = recv_pkt.frame.height * recv_pkt.frame.step;
       camera_name = recv_pkt.frame.camera_name;

--- a/ovc5/software/libovc/src/server.cpp
+++ b/ovc5/software/libovc/src/server.cpp
@@ -81,6 +81,8 @@ void Server::receiveThread()
       ret_imgs[camera_id].t_sec = recv_pkt.frame.t_sec;
       ret_imgs[camera_id].t_nsec = recv_pkt.frame.t_nsec;
       ret_imgs[camera_id].frame_id = recv_pkt.frame.frame_id;
+      ret_imgs[camera_id].color_format =
+          color_code_map.at(recv_pkt.frame.data_type);
 
       frame_size = recv_pkt.frame.height * recv_pkt.frame.step;
       camera_name = recv_pkt.frame.camera_name;

--- a/ovc5/software/libovc/src/server.cpp
+++ b/ovc5/software/libovc/src/server.cpp
@@ -81,7 +81,8 @@ void Server::receiveThread()
       ret_imgs[camera_id].t_sec = recv_pkt.frame.t_sec;
       ret_imgs[camera_id].t_nsec = recv_pkt.frame.t_nsec;
       ret_imgs[camera_id].frame_id = recv_pkt.frame.frame_id;
-      ret_imgs[camera_id].color_format = color_code_map.at(recv_pkt.frame.data_type);
+      ret_imgs[camera_id].color_format =
+          color_code_map.at(recv_pkt.frame.data_type);
 
       frame_size = recv_pkt.frame.height * recv_pkt.frame.step;
       camera_name = recv_pkt.frame.camera_name;


### PR DESCRIPTION
This adds the ability to tell the host what order sub-pixels are arriving in. This allows a variety of cameras to be processed at once with different sub-pixel orderings and patterns (currently only using Bayer).