### PR TITLE
Dynamic Parameters

### DIFF
--- a/ovc5/software/camera_device_driver/include/ovc5_driver/camera.hpp
+++ b/ovc5/software/camera_device_driver/include/ovc5_driver/camera.hpp
@@ -6,6 +6,12 @@
 #include "ovc5_driver/i2c_driver.h"
 #include "ovc5_driver/vdma_driver.h"
 
+typedef struct camera_dynamic_configs_t
+{
+  bool frame_rate : 1 = false;
+  bool exposure : 1 = false;
+} camera_dynamic_configs_t;
+
 typedef struct camera_params_t
 {
   int res_x = -1;
@@ -13,6 +19,7 @@ typedef struct camera_params_t
   int fps = -1;
   int bit_depth = -1;
   char data_type[8];
+  camera_dynamic_configs_t dynamic_configs;
 } camera_params_t;
 
 // TODO move to separate shared header if we want to serialize manually
@@ -63,6 +70,9 @@ public:
   // Triggering main / secondary device settings
   virtual void setMain(){};
   virtual void setSecondary(){};
+
+  // Camera dynamic parameter functions.
+  virtual void updateExposure(float ms){};
 };
 
 #endif

--- a/ovc5/software/camera_device_driver/include/ovc5_driver/camera.hpp
+++ b/ovc5/software/camera_device_driver/include/ovc5_driver/camera.hpp
@@ -8,8 +8,8 @@
 
 typedef struct camera_dynamic_configs_t
 {
-  bool frame_rate : 1 = false;
-  bool exposure : 1 = false;
+  bool frame_rate : 1;
+  bool exposure : 1;
 } camera_dynamic_configs_t;
 
 typedef struct camera_params_t
@@ -19,7 +19,7 @@ typedef struct camera_params_t
   int fps = -1;
   int bit_depth = -1;
   char data_type[8];
-  camera_dynamic_configs_t dynamic_configs;
+  camera_dynamic_configs_t dynamic_configs = {0};
 } camera_params_t;
 
 // TODO move to separate shared header if we want to serialize manually

--- a/ovc5/software/camera_device_driver/include/ovc5_driver/sensor_manager.hpp
+++ b/ovc5/software/camera_device_driver/include/ovc5_driver/sensor_manager.hpp
@@ -29,10 +29,12 @@ class SensorManager
 private:
   // Number of lines to wait before tranferring frame
   static constexpr int LINE_BUFFER_SIZE = 400;
+  static constexpr float DEFAULT_FRAME_RATE = 15.0;
 
   EthernetClient client;
 
   Timer line_counter;
+  Timer trigger_timer;
 
   std::unique_ptr<GPIOChip> gpio;
 
@@ -44,7 +46,7 @@ private:
 
 public:
   SensorManager(const std::vector<camera_config_t>& cams, int line_counter_dev,
-                int primary_cam);
+                int trigger_timer_dev, int primary_cam);
 
   void initCameras();
 

--- a/ovc5/software/camera_device_driver/src/ovc5_driver.cpp
+++ b/ovc5/software/camera_device_driver/src/ovc5_driver.cpp
@@ -78,7 +78,6 @@ int main(int argc, char **argv)
   while (!stop)
   {
     std::cout << "Waiting for frames" << std::endl;
-    // sm.getFramesStereo();
     sm.sendFrames();
     sm.recvCommand();
   }

--- a/ovc5/software/camera_device_driver/src/ovc5_driver.cpp
+++ b/ovc5/software/camera_device_driver/src/ovc5_driver.cpp
@@ -57,8 +57,10 @@ int main(int argc, char **argv)
   config_t config;
   load_config(config);
 
-  SensorManager sm(
-      config.cams, config.line_count_timer_dev, config.trigger_timer_dev, config.primary_cam);
+  SensorManager sm(config.cams,
+                   config.line_count_timer_dev,
+                   config.trigger_timer_dev,
+                   config.primary_cam);
 
   if (argc > 1)
   {

--- a/ovc5/software/camera_device_driver/src/ovc5_driver.cpp
+++ b/ovc5/software/camera_device_driver/src/ovc5_driver.cpp
@@ -58,12 +58,7 @@ int main(int argc, char **argv)
   load_config(config);
 
   SensorManager sm(
-      config.cams, config.line_count_timer_dev, config.primary_cam);
-  Timer trigger_timer(config.trigger_timer_dev);
-
-  // Hz, high time
-  // trigger_timer.PWM(15.0, 0.0001);
-  // trigger_timer.PWM(20.0, 0.001);
+      config.cams, config.line_count_timer_dev, config.trigger_timer_dev, config.primary_cam);
 
   if (argc > 1)
   {

--- a/ovc5/software/camera_device_driver/src/sensor_manager.cpp
+++ b/ovc5/software/camera_device_driver/src/sensor_manager.cpp
@@ -148,7 +148,8 @@ void SensorManager::recvCommand()
   }
   for (auto &[cam_id, camera] : cameras)
   {
-    if (camera->getCameraParams().dynamic_configs.exposure) {
+    if (camera->getCameraParams().dynamic_configs.exposure)
+    {
       camera->updateExposure(pkt->config.exposure);
     }
   }

--- a/ovc5/software/camera_device_driver/src/sensor_manager.cpp
+++ b/ovc5/software/camera_device_driver/src/sensor_manager.cpp
@@ -8,8 +8,11 @@
 #include "ovc5_driver/i2c_driver.h"
 
 SensorManager::SensorManager(const std::vector<camera_config_t> &cams,
-                             int line_counter_dev, int primary_cam)
-    : line_counter(line_counter_dev), primary_cam_(primary_cam)
+                             int line_counter_dev, int trigger_timer_dev,
+                             int primary_cam)
+    : line_counter(line_counter_dev),
+      trigger_timer(trigger_timer_dev),
+      primary_cam_(primary_cam)
 {
   // Configure the gpio chip.
   gpio = std::make_unique<GPIOChip>(GPIO_CHIP_NUMBER);
@@ -38,6 +41,9 @@ SensorManager::SensorManager(const std::vector<camera_config_t> &cams,
   // Open pin for triggering samples.
   gpio->openPin(GPIO_TRIG_PIN, GPIO_OUTPUT);
   gpio->setValue(GPIO_LED_PIN, false);
+
+  // Set up trigger timer at the configured frequency.
+  trigger_timer.PWM(DEFAULT_FRAME_RATE, 0.001);
 
   // Sleep for a bit to allow cameras to boot up.
   usleep(100000);
@@ -143,9 +149,16 @@ void SensorManager::recvCommand()
   }
   if (RX_PACKET_TYPE_CMD_CONFIG == pkt->packet_type)
   {
-    std::cout << "Received config packet with {exposure: "
-              << pkt->config.exposure << "}" << std::endl;
+    printf(
+        "Received config packet with "
+        "{exposure: %f}"
+        "{frame_rate: %f}",
+        pkt->config.exposure,
+        pkt->config.frame_rate);
   }
+
+  trigger_timer.PWM(pkt->config.frame_rate, 0.001);
+
   for (auto &[cam_id, camera] : cameras)
   {
     if (camera->getCameraParams().dynamic_configs.exposure)

--- a/ovc5/software/camera_device_driver/src/sensor_manager.cpp
+++ b/ovc5/software/camera_device_driver/src/sensor_manager.cpp
@@ -146,6 +146,12 @@ void SensorManager::recvCommand()
     std::cout << "Received config packet with {exposure: "
               << pkt->config.exposure << "}" << std::endl;
   }
+  for (auto &[cam_id, camera] : cameras)
+  {
+    if (camera->getCameraParams().dynamic_configs.exposure) {
+      camera->updateExposure(pkt->config.exposure);
+    }
+  }
 }
 
 int SensorManager::getNumCameras() const { return cameras.size(); }

--- a/ovc5/software/libovc/include/libovc/ethernet_packetdef.hpp
+++ b/ovc5/software/libovc/include/libovc/ethernet_packetdef.hpp
@@ -61,7 +61,7 @@ typedef enum : uint32_t
 
 typedef struct __attribute__((__packed__))
 {
-  double exposure;
+  float exposure;
 } ether_rx_config_t;
 
 typedef union __attribute__((__packed__))

--- a/ovc5/software/libovc/include/libovc/ethernet_packetdef.hpp
+++ b/ovc5/software/libovc/include/libovc/ethernet_packetdef.hpp
@@ -62,6 +62,7 @@ typedef enum : uint32_t
 typedef struct __attribute__((__packed__))
 {
   float exposure;
+  float frame_rate;
 } ether_rx_config_t;
 
 typedef union __attribute__((__packed__))

--- a/ovc5/software/libovc/include/libovc/ovc.hpp
+++ b/ovc5/software/libovc/include/libovc/ovc.hpp
@@ -3,7 +3,10 @@
 
 #include <thread>
 
-#include "server.hpp"
+#include "libovc/ethernet_packetdef.hpp"
+#include "libovc/server.hpp"
+
+#define config_t ether_rx_config_t
 
 namespace libovc
 {
@@ -19,7 +22,7 @@ public:
   ~OVC();
 
   std::array<OVCImage, Server::NUM_IMAGERS> getFrames();
-  void updateConfig(float exposure);
+  void updateConfig(config_t config);
 
   int getNumImagers() { return Server::NUM_IMAGERS; }
 };

--- a/ovc5/software/libovc/include/libovc/ovc.hpp
+++ b/ovc5/software/libovc/include/libovc/ovc.hpp
@@ -19,7 +19,7 @@ public:
   ~OVC();
 
   std::array<OVCImage, Server::NUM_IMAGERS> getFrames();
-  void updateConfig(double exposure);
+  void updateConfig(float exposure);
 
   int getNumImagers() { return Server::NUM_IMAGERS; }
 };

--- a/ovc5/software/libovc/src/ovc.cpp
+++ b/ovc5/software/libovc/src/ovc.cpp
@@ -54,10 +54,8 @@ std::array<OVCImage, Server::NUM_IMAGERS> OVC::getFrames()
   return frames_;
 }
 
-void OVC::updateConfig(float exposure)
+void OVC::updateConfig(config_t config)
 {
-  ether_rx_config_t config;
-  config.exposure = exposure;
   server_.updateConfig(config);
 }
 

--- a/ovc5/software/libovc/src/ovc.cpp
+++ b/ovc5/software/libovc/src/ovc.cpp
@@ -54,7 +54,7 @@ std::array<OVCImage, Server::NUM_IMAGERS> OVC::getFrames()
   return frames_;
 }
 
-void OVC::updateConfig(double exposure)
+void OVC::updateConfig(float exposure)
 {
   ether_rx_config_t config;
   config.exposure = exposure;

--- a/ovc5/software/libovc/src/ovc.cpp
+++ b/ovc5/software/libovc/src/ovc.cpp
@@ -54,9 +54,6 @@ std::array<OVCImage, Server::NUM_IMAGERS> OVC::getFrames()
   return frames_;
 }
 
-void OVC::updateConfig(config_t config)
-{
-  server_.updateConfig(config);
-}
+void OVC::updateConfig(config_t config) { server_.updateConfig(config); }
 
 }  // namespace libovc

--- a/ovc5/software/ros_drivers/ros1/cfg/Params.cfg
+++ b/ovc5/software/ros_drivers/ros1/cfg/Params.cfg
@@ -6,6 +6,6 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("exposure", float_t, 0, "The exposure of the cameras in milliseconds. Limited by one over max frame rate.", .5, 0.0, 1000.0)
+gen.add("exposure", double_t, 0, "The exposure of the cameras in milliseconds. Limited by one over max frame rate.", .5, 0.0, 1000.0)
 
 exit(gen.generate(PACKAGE, PACKAGE, "Params"))

--- a/ovc5/software/ros_drivers/ros1/cfg/Params.cfg
+++ b/ovc5/software/ros_drivers/ros1/cfg/Params.cfg
@@ -6,6 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("exposure", double_t, 0, "The exposure of the cameras in milliseconds. Limited by one over max frame rate.", .5, 0.0, 1000.0)
+gen.add("exposure", double_t, 0, "The exposure of the cameras in milliseconds. Limited by one over max frame rate.", 10.0, 0.0, 1000.0)
+gen.add("frame_rate", double_t, 0, "The number of frames per second in Hertz.", 30.0, 0.0, 120.0)
 
 exit(gen.generate(PACKAGE, PACKAGE, "Params"))

--- a/ovc5/software/ros_drivers/ros1/cfg/Params.cfg
+++ b/ovc5/software/ros_drivers/ros1/cfg/Params.cfg
@@ -6,6 +6,6 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
-gen.add("exposure", double_t, 0, "The exposure of the cameras.", .5, 0.0, 1.0)
+gen.add("exposure", float_t, 0, "The exposure of the cameras in milliseconds. Limited by one over max frame rate.", .5, 0.0, 1000.0)
 
 exit(gen.generate(PACKAGE, PACKAGE, "Params"))

--- a/ovc5/software/ros_drivers/ros1/src/ovc_driver.cpp
+++ b/ovc5/software/ros_drivers/ros1/src/ovc_driver.cpp
@@ -31,8 +31,8 @@ public:
     (void)level;
 
     config_t cam_config = {
-        .exposure = (float) config.exposure,
-        .frame_rate = (float) config.frame_rate,
+        .exposure = (float)config.exposure,
+        .frame_rate = (float)config.frame_rate,
     };
     ROS_INFO(
         "Reconfigure Request "

--- a/ovc5/software/ros_drivers/ros1/src/ovc_driver.cpp
+++ b/ovc5/software/ros_drivers/ros1/src/ovc_driver.cpp
@@ -29,8 +29,18 @@ public:
   void reconfigure_callback(ovc_driver::ParamsConfig &config, uint32_t level)
   {
     (void)level;
-    ROS_INFO("Reconfigure Request {exposure: %f}", config.exposure);
-    ovc_.updateConfig((float)config.exposure);
+
+    config_t cam_config = {
+        .exposure = (float) config.exposure,
+        .frame_rate = (float) config.frame_rate,
+    };
+    ROS_INFO(
+        "Reconfigure Request "
+        "{exposure: %f}"
+        "{frame_rate: %f}",
+        cam_config.exposure,
+        cam_config.frame_rate);
+    ovc_.updateConfig(cam_config);
   }
 
   void spinOnce()

--- a/ovc5/software/ros_drivers/ros1/src/ovc_driver.cpp
+++ b/ovc5/software/ros_drivers/ros1/src/ovc_driver.cpp
@@ -30,7 +30,7 @@ public:
   {
     (void)level;
     ROS_INFO("Reconfigure Request {exposure: %f}", config.exposure);
-    ovc_.updateConfig(config.exposure);
+    ovc_.updateConfig((float)config.exposure);
   }
 
   void spinOnce()

--- a/ovc5/software/ros_drivers/ros2/src/ovc_driver.cpp
+++ b/ovc5/software/ros_drivers/ros2/src/ovc_driver.cpp
@@ -20,7 +20,7 @@ public:
     RCLCPP_INFO(this->get_logger(), "Initialize libovc.");
     ovc_ = std::make_shared<libovc::OVC>();
 
-    this->declare_parameter<double>("exposure", exposure_);
+    this->declare_parameter<float>("exposure", exposure_);
     // Create the camera publishers.
     for (size_t i = 0; i < publishers_.size(); i++)
     {
@@ -75,7 +75,7 @@ private:
 
   void updateParams()
   {
-    double new_exposure;
+    float new_exposure;
     this->get_parameter("exposure", new_exposure);
     if (new_exposure != exposure_)
     {
@@ -96,7 +96,7 @@ private:
   rclcpp::Time begin_;
 
   // Camera Params.
-  double exposure_;
+  float exposure_;
 };
 
 int main(int argc, char **argv)

--- a/ovc5/software/ros_drivers/ros2/src/ovc_driver.cpp
+++ b/ovc5/software/ros_drivers/ros2/src/ovc_driver.cpp
@@ -14,13 +14,15 @@ public:
   OVCPublisher() : Node("ovc_publisher")
   {
     // Set all default values.
-    exposure_ = 0.5;
+    config_.exposure = 10;  // ms
+    config_.frame_rate = 30;  // Hz
     frame_count = 0;
 
     RCLCPP_INFO(this->get_logger(), "Initialize libovc.");
     ovc_ = std::make_shared<libovc::OVC>();
 
-    this->declare_parameter<float>("exposure", exposure_);
+    this->declare_parameter<float>("exposure", config_.exposure);
+    this->declare_parameter<float>("frame_rate", config_.frame_rate);
     // Create the camera publishers.
     for (size_t i = 0; i < publishers_.size(); i++)
     {
@@ -75,15 +77,19 @@ private:
 
   void updateParams()
   {
-    float new_exposure;
-    this->get_parameter("exposure", new_exposure);
-    if (new_exposure != exposure_)
+    config_t new_config;
+    this->get_parameter("exposure", new_config.exposure);
+    this->get_parameter("frame_rate", new_config.frame_rate);
+    if (new_config != config_)
     {
       RCLCPP_INFO(this->get_logger(),
-                  "Recevied param update {exposure: %f}",
-                  new_exposure);
-      exposure_ = new_exposure;
-      ovc_->updateConfig(exposure_);
+                  "Recevied param update "
+                  "{exposure: %f}"
+                  "{frame_rate: %f}",
+                  new_config.exposure,
+                  new_config.frame_rate);
+      config_ = new_config;
+      ovc_->updateConfig(config_.exposure);
     }
   }
 
@@ -96,7 +102,7 @@ private:
   rclcpp::Time begin_;
 
   // Camera Params.
-  float exposure_;
+  config_t config_;
 };
 
 int main(int argc, char **argv)

--- a/ovc5/software/ros_drivers/ros2/src/ovc_driver.cpp
+++ b/ovc5/software/ros_drivers/ros2/src/ovc_driver.cpp
@@ -14,7 +14,7 @@ public:
   OVCPublisher() : Node("ovc_publisher")
   {
     // Set all default values.
-    config_.exposure = 10;  // ms
+    config_.exposure = 10;    // ms
     config_.frame_rate = 30;  // Hz
     frame_count = 0;
 


### PR DESCRIPTION
Enables live parameter updates for cameras via host-provided values. Currently applies to all connected cameras but it should be possible to select a camera in particular that will be modified (add a camera number to the header).

If we go with that solution down the road, it will only allow for one camera to be modified at a time but I think that's acceptable?