### PR TITLE
Only run clang format check on PR

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,6 +1,6 @@
 name: clang-format Check
 # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   formatting-check:
     name: Formatting Check


### PR DESCRIPTION
Every push to a PR was causing a double build job. I don't believe it'll be necessary to build on push since we mostly care about master.

Signed-off-by: Greg Balke <greg@openrobotics.org>