### PR TITLE
Fix spelling and correct cmake behavior

### DIFF
--- a/ovc5/software/Makefile
+++ b/ovc5/software/Makefile
@@ -10,11 +10,11 @@ host_driver: libovc
 
 device_driver_proprietary: libovc
 	mkdir -p camera_device_driver/build
-	cd camera_device_driver/build && cmake -DPROPRIETARY_SENSORS=TRUE ../ && make
+	cd camera_device_driver/build && cmake -DPROPRIETARY_SENSORS=ON ../ && make
 
 device_driver: libovc
 	mkdir -p camera_device_driver/build
-	cd camera_device_driver/build && cmake ../ && make
+	cd camera_device_driver/build && cmake -DPROPRIETARY_SENSORS=OFF ../ && make
 
 run_host: camera_host_driver
 	./camera_host_driver/build/ovc5_host_node

--- a/ovc5/software/camera_device_driver/CMakeLists.txt
+++ b/ovc5/software/camera_device_driver/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(ovc5_driver)
 
-option(PROPRIETARY_SENSORS "Whether to include proprietary sensors." 0)
+option(PROPRIETARY_SENSORS "Whether to include proprietary sensors." OFF)
 
 include_directories(
   include
@@ -19,8 +19,9 @@ add_library(ovc5_library
 
 target_compile_features(ovc5_library PUBLIC cxx_std_17)
 target_compile_options(ovc5_library PUBLIC -Wall -O3)
-if(PROPIETARY_SENSORS)
-  target_compile_definitions(ovc5_library PUBLIC -DPROPRITARY_SENSORS)
+if(PROPRIETARY_SENSORS)
+  message("Proprietary Sensors Enabled")
+  target_compile_definitions(ovc5_library PUBLIC -DPROPRIETARY_SENSORS)
 endif()
 
 target_link_libraries(ovc5_library


### PR DESCRIPTION
#65 was flawed. This fixes the mistakes. It might be reasonable to add CI to double check the behavior but I don't think this will be modified much past this point.